### PR TITLE
Using import as default + having @ungap/esxtoken as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,11 +23,11 @@
     "@babel/cli": "^7.19.3",
     "@babel/core": "^7.20.2",
     "@types/babel__core": "^7.1.20",
-    "@ungap/esxtoken": "github:ungap/esxtoken",
     "prettier": "^2.7.1"
   },
   "dependencies": {
-    "@babel/plugin-syntax-jsx": "^7.18.6"
+    "@babel/plugin-syntax-jsx": "^7.18.6",
+    "@ungap/esxtoken": "^0.1.0"
   },
   "peerDependencies": {
     "@babel/core": "^7.20.2"

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import { getInlinePolyfill, getExternalPolyfill } from "./polyfill.js";
 /**
  * @param {import("@babel/core")} babelApi
  */
-export default function ({ template, types: t }, { polyfill = "inline" }) {
+export default function ({ template, types: t }, { polyfill = "import" } = {}) {
   if (polyfill !== false && polyfill !== "inline" && polyfill !== "import") {
     throw new Error(
       `The .polyfill option must be one of: false, "inline", "import".`

--- a/test/index.js
+++ b/test/index.js
@@ -74,8 +74,8 @@ test("'polyfill' option", () => {
       `ESXToken.template(_templateReference, ESXToken.element("div", null));`
   );
 
-  // Default is inline
-  assert.strictEqual(withOpts({}), withOpts({ polyfill: "inline" }));
+  // Default is import
+  assert.strictEqual(withOpts({}), withOpts({ polyfill: "import" }));
 });
 
 test("type of element attributes", () => {


### PR DESCRIPTION
This MR fixes default expectations and uses `@ungap/esxtoken` by default and as dependency.

/cc @nicolo-ribaudo 