### PR TITLE
v0.2 with perf and structural changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "src/index.js",
   "type": "module",
   "scripts": {
+    "test:all": "rm -rf ./test/transform/output.js && npm run test:build && npm run test",
     "test:build": "babel ./test/index.js -o ./test/index.compiled.js",
     "test": "npm run test:build && node ./test/index.compiled.js"
   },
@@ -24,13 +25,13 @@
   "homepage": "https://github.com/ungap/babel-plugin-transform-esx#readme",
   "devDependencies": {
     "@babel/cli": "^7.19.3",
-    "@babel/core": "^7.20.2",
+    "@babel/core": "^7.20.5",
     "@types/babel__core": "^7.1.20",
-    "prettier": "^2.7.1"
+    "prettier": "^2.8.0"
   },
   "dependencies": {
     "@babel/plugin-syntax-jsx": "^7.18.6",
-    "@ungap/esxtoken": "^0.1.2",
+    "@ungap/esxtoken": "^0.2.2",
     "umeta": "^0.2.4"
   },
   "peerDependencies": {

--- a/src/inline.js
+++ b/src/inline.js
@@ -5,5 +5,5 @@ import umeta from 'umeta';
 const {require} = umeta(import.meta);
 
 export default readFileSync(require.resolve('@ungap/esxtoken')).toString()
-                .replace(/^[\s\S]+?class/, 'globalThis.ESXToken || (globalThis.ESXToken = class')
+                .replace(/^[\s\S]+?\(\(/, 'globalThis.ESXToken || (globalThis.ESXToken = ((')
                 .replace(/;?\s*$/, ');\n');

--- a/test/transform/output.js
+++ b/test/transform/output.js
@@ -3,41 +3,21 @@ var _templateReference = {},
   _templateReference3 = {},
   _templateReference4 = {};
 import ESXToken from "@ungap/esxtoken";
-const div = ESXToken.template(
-  _templateReference,
-  ESXToken.element("div", null)
-);
-const div2 = ESXToken.template(
+const div = ESXToken.e(_templateReference, "div", ESXToken._);
+const div2 = ESXToken.e(
   _templateReference2,
-  ESXToken.element(
-    "div",
-    ESXToken.create(ESXToken.MIXED_TYPE, [
-      ESXToken.property(ESXToken.STATIC_TYPE, "a", "a"),
-      ESXToken.property(ESXToken.RUNTIME_TYPE, "b", "b"),
-    ]),
-    ESXToken.create(
-      ESXToken.STATIC_TYPE,
-      ESXToken.element("p", null, ESXToken.create(ESXToken.STATIC_TYPE, "c"))
-    )
-  )
+  "div",
+  [ESXToken.a(false, "a", "a"), ESXToken.a(true, "b", "b")],
+  [ESXToken.e(null, "p", ESXToken._, [ESXToken.s("c")])]
 );
 function MyComponent(...args) {
-  return ESXToken.template(
-    _templateReference3,
-    ESXToken.fragment(
-      ESXToken.create(ESXToken.RUNTIME_TYPE, "A"),
-      ESXToken.create(ESXToken.STATIC_TYPE, ","),
-      ESXToken.create(ESXToken.RUNTIME_TYPE, "B")
-    )
-  );
+  return ESXToken.f(_templateReference3, [
+    ESXToken.i("A"),
+    ESXToken.s(","),
+    ESXToken.i("B"),
+  ]);
 }
-const component = ESXToken.template(
-  _templateReference4,
-  ESXToken.component(
-    MyComponent,
-    ESXToken.create(ESXToken.RUNTIME_TYPE, [
-      ESXToken.property(ESXToken.STATIC_TYPE, "a", "a"),
-      ESXToken.property(ESXToken.RUNTIME_TYPE, "", props),
-    ])
-  )
-);
+const component = ESXToken.c(_templateReference4, MyComponent, [
+  ESXToken.a(false, "a", "a"),
+  ESXToken.i(props),
+]);


### PR DESCRIPTION
The current MR is [based on latest discussions](https://es.discourse.group/t/proposal-esx-as-core-js-feature/1511/42) and it provides the following changes/optimizations:

  * there is no outer structure for templates. A node either has an `id` if outer template, or it's `null`.
  * there is no `properties` wrapper. Everything is part of the `attributes` field which is always an array.
  * the `properties` is an accessor utility to forward props when/if needed and mostly to components.
  * fragments, elements, and components, share the same `ESXNode` class
  * attributes is a list of either attributes or interpolations. The whole mixed vs runtime vs static type is gone. Attributes have a `dynamic` field when these are not interpolations but interpolations simply carry their spread value.
  * dropped variadity on `children`, it's always an array to crawl and it defaults to an (always same) empty array. The same is for attributes to avoid bloating the heap or GC with create and trash operations.
  * static children have type `ESXToken.STATIC` and their value will be the string they represent.
  * interpolations as children have `ESXToken.INTERPOLATION` type and carry their current value

### New Structure

Please find in the poly repo the latest abstract description of the proposal.
https://github.com/ungap/esxtoken#esxtoken

/cc @nicolo-ribaudo 